### PR TITLE
Attempt to fix the failure in the coverage step of the GH actions

### DIFF
--- a/.github/workflows/GitHub_Actions_CI.yaml
+++ b/.github/workflows/GitHub_Actions_CI.yaml
@@ -65,22 +65,13 @@ jobs:
             token = "${{ secrets.CODECOV_TOKEN }}",
             install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
-          covr::to_cobertura(cov)
         shell: Rscript {0}
-
-      - uses: codecov/codecov-action@v4
-        with:
-          fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
-          file: ./cobertura.xml
-          plugin: noop
-          disable_search: true
-          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()
         run: |
           ## --------------------------------------------------------------------
-          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
       - name: Upload test results


### PR DESCRIPTION
Currently it fails with this error:
```
   Error: Error in loadNamespace(xml2) : there is no package called ‘xml2’
```

We don't use package `xml2`, but it's required by `covr::to_cobertura()`.